### PR TITLE
Add leaderboard reset button

### DIFF
--- a/jornet-server-ui/src/pages/dashboard.tsx
+++ b/jornet-server-ui/src/pages/dashboard.tsx
@@ -217,6 +217,7 @@ class DashboardInner extends Component<DashboardProps, DashboardState> {
                                     <th>Leaderboard</th>
                                     <th>Scores</th>
                                     <th>ID</th>
+                                    <th></th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -232,6 +233,15 @@ class DashboardInner extends Component<DashboardProps, DashboardState> {
                                             <td style={{ display: "flex" }}>
                                                 <p className="font-monospace">{leaderboard.id}</p>
                                                 <ClipboardHelper to_copy={leaderboard.id} />
+                                            </td>
+                                            <td>
+                                                <Button
+                                                    variant="primary"
+                                                    data-leaderboard-id={leaderboard.id}
+                                                    onClick={this.handleResetLeaderboard}
+                                                >
+                                                    Reset
+                                                </Button>
                                             </td>
                                         </tr>
                                     })
@@ -263,6 +273,25 @@ class DashboardInner extends Component<DashboardProps, DashboardState> {
                 leaderboards.push(data)
                 this.setState({ leaderboards: leaderboards });
                 this.setState({ new_leaderboard_data: data });
+            }).catch(error => {
+                this.props.setLoginInfo(undefined);
+                this.props.setToken(undefined);
+            });
+        event.preventDefault();
+    }
+    handleResetLeaderboard = (event: React.FormEvent) => {
+        let leaderboardId = event.currentTarget.getAttribute('data-leaderboard-id');
+        const requestOptions = {
+            method: 'DELETE',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': 'Bearer ' + this.props.token!
+            },
+        };
+        fetch('/api/v1/scores/' + leaderboardId, requestOptions)
+            .then(response => response.json())
+            .then(data => {
+                // TODO
             }).catch(error => {
                 this.props.setLoginInfo(undefined);
                 this.props.setToken(undefined);

--- a/jornet-server-ui/src/pages/dashboard.tsx
+++ b/jornet-server-ui/src/pages/dashboard.tsx
@@ -288,7 +288,7 @@ class DashboardInner extends Component<DashboardProps, DashboardState> {
                 'Authorization': 'Bearer ' + this.props.token!
             },
         };
-        fetch('/api/v1/scores/' + leaderboardId, requestOptions)
+        fetch('/api/v1/leaderboards/' + leaderboardId + '/scores', requestOptions)
             .then(response => response.json())
             .then(data => {
                 // TODO

--- a/jornet-server/src/domains/score.rs
+++ b/jornet-server/src/domains/score.rs
@@ -94,6 +94,13 @@ async fn get_scores(connection: web::Data<PgPool>, leaderboard: web::Path<Uuid>)
     HttpResponse::Ok().json(Score::get_all(&connection, &leaderboard).await)
 }
 
+async fn delete_scores(
+    connection: web::Data<PgPool>,
+    leaderboard: web::Path<Uuid>,
+) -> impl Responder {
+    HttpResponse::Ok().json(Score::delete_all(&connection, &leaderboard).await)
+}
+
 pub(crate) fn score() -> impl HttpServiceFactory {
     let cors = Cors::default()
         .allow_any_header()
@@ -105,6 +112,7 @@ pub(crate) fn score() -> impl HttpServiceFactory {
         .wrap(cors)
         .route("{leaderboard_id}", web::post().to(save_score))
         .route("{leaderboard_id}", web::get().to(get_scores))
+        .route("{leaderboard_id}", web::delete().to(delete_scores))
 }
 
 impl Score {
@@ -167,5 +175,12 @@ impl Score {
             .execute(connection)
             .await
         .is_ok()
+    }
+
+    pub async fn delete_all(connection: &PgPool, leaderboard: &Uuid) -> bool {
+        sqlx::query!("DELETE FROM scores WHERE leaderboard = $1", leaderboard)
+            .execute(connection)
+            .await
+            .is_ok()
     }
 }

--- a/jornet-server/src/domains/score.rs
+++ b/jornet-server/src/domains/score.rs
@@ -94,13 +94,6 @@ async fn get_scores(connection: web::Data<PgPool>, leaderboard: web::Path<Uuid>)
     HttpResponse::Ok().json(Score::get_all(&connection, &leaderboard).await)
 }
 
-async fn delete_scores(
-    connection: web::Data<PgPool>,
-    leaderboard: web::Path<Uuid>,
-) -> impl Responder {
-    HttpResponse::Ok().json(Score::delete_all(&connection, &leaderboard).await)
-}
-
 pub(crate) fn score() -> impl HttpServiceFactory {
     let cors = Cors::default()
         .allow_any_header()
@@ -112,7 +105,6 @@ pub(crate) fn score() -> impl HttpServiceFactory {
         .wrap(cors)
         .route("{leaderboard_id}", web::post().to(save_score))
         .route("{leaderboard_id}", web::get().to(get_scores))
-        .route("{leaderboard_id}", web::delete().to(delete_scores))
 }
 
 impl Score {
@@ -175,12 +167,5 @@ impl Score {
             .execute(connection)
             .await
         .is_ok()
-    }
-
-    pub async fn delete_all(connection: &PgPool, leaderboard: &Uuid) -> bool {
-        sqlx::query!("DELETE FROM scores WHERE leaderboard = $1", leaderboard)
-            .execute(connection)
-            .await
-            .is_ok()
     }
 }


### PR DESCRIPTION
It was a pretty amazing journey getting set up to develop and test this tiny changeset.

It's pretty basic. UI doesn't update when resetting.

Would be great to have this functionality when the bevy jam voting period begins. It's a bit of an ordeal to rebuild and re-upload to swap to a fresh leaderboard.