### PR TITLE
Send some events when calls finish

### DIFF
--- a/bevy-jornet/src/leaderboards.rs
+++ b/bevy-jornet/src/leaderboards.rs
@@ -13,6 +13,7 @@ use uuid::Uuid;
 
 use crate::http;
 
+/// Bevy Event that is sent when calls to Jornet finish.
 pub enum JornetEvent {
     /// A call to [`send_score`] succeeded.
     SendScoreSuccess,

--- a/bevy-jornet/src/lib.rs
+++ b/bevy-jornet/src/lib.rs
@@ -6,14 +6,15 @@
 //! - save high scores
 //! - get a leaderboard
 
-use bevy::prelude::{App, Plugin};
+use bevy::prelude::{App, IntoSystemConfig, Plugin};
+use leaderboards::send_events;
 pub use leaderboards::Leaderboard;
 use uuid::Uuid;
 
 mod http;
 mod leaderboards;
 
-pub use leaderboards::{done_refreshing_leaderboard, Player, Score};
+pub use leaderboards::{done_refreshing_leaderboard, JornetEvent, Player, Score};
 
 /// Bevy Plugin handling communications with the Jornet server.
 pub struct JornetPlugin {
@@ -50,7 +51,9 @@ impl Plugin for JornetPlugin {
     fn build(&self, app: &mut App) {
         let leaderboard =
             Leaderboard::with_host_and_leaderboard(self.host.clone(), self.leaderboard, self.key);
-        app.insert_resource(leaderboard)
-            .add_system(done_refreshing_leaderboard);
+        app.add_event::<JornetEvent>()
+            .insert_resource(leaderboard)
+            .add_system(done_refreshing_leaderboard)
+            .add_system(send_events.after(done_refreshing_leaderboard));
     }
 }


### PR DESCRIPTION
Fixes #178

Opening this up just to bring some code to the table. Last year something similar (but with a separate event type for each call) worked well for me.

This is based on #53, but adds more feedback for `bevy_jornet` users.